### PR TITLE
Use rimraf to clean-up temporary folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 - Update Prettier rules (see #41).
 
+- Use `rimraf` instead of `rm -rf` (see #42).
+
 - Update dev dependencies to latest version.
 
 ### [v0.1.1](https://github.com/RobotlegsJS/RobotlegsJS-Pixi-Palidor/releases/tag/0.1.1) - 2017-11-23

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "mocha": "mocha test/**/*.test.ts --require ts-node/register",
     "autoformat": "prettier --config .prettierrc --write {example,src,test}/**/*.ts",
     "tslint-check": "tslint-config-prettier-check ./tslint.json",
-    "clean-up": "rm -rf .nyc_output && rm -rf coverage && rm -rf lib",
+    "clean-up": "rimraf .nyc_output && rimraf coverage && rimraf lib",
     "prepare": "npm run clean-up && tsc -d",
     "prepublishOnly": "publish-please guard",
     "publish-please": "npm run autoformat && npm run clean-up && npm run test && publish-please"


### PR DESCRIPTION
Use `rimraf` instead of `rm -rf` to clean-up temporary folders.