### PR TITLE
Fix typo in class named PixiContainerController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@
 
 ### v0.2.0
 
+Major Breaking Changes:
+---
+
+- Fix typo in class named **PixiContainerController** (see #44).
+    - The name of the class changed from **PixiContainerContoller** to **PixiContainerController**, don't forget to update your import statements.
+    - A copyright message was added to all source files.
+
+Features Or Improvements:
+---
+
 - Added *PalidorBundle* class (see #41).
 
 - Added example project (see #41).
@@ -25,8 +35,6 @@
 - Use `rimraf` instead of `rm -rf` (see #42).
 
 - Update TypeScript Compiler Options (see #43).
-
-- Fix typo in class name PixiContainerController (see #44).
 
 - Update dev dependencies to latest version.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@
 
   - [ ] Find a way to keep a new line between **@inject** anotation and property declarations.
 
-## RobotlegsJS-Pixi-Palidor 0.1.0
+## RobotlegsJS-Pixi-Palidor 0.2.0
 
-### v0.1.2
+### v0.2.0
 
 - Added *PalidorBundle* class (see #41).
 
@@ -26,7 +26,11 @@
 
 - Update TypeScript Compiler Options (see #43).
 
+- Rename class to PixiContainerController (see #44).
+
 - Update dev dependencies to latest version.
+
+## RobotlegsJS-Pixi-Palidor 0.1.0
 
 ### [v0.1.1](https://github.com/RobotlegsJS/RobotlegsJS-Pixi-Palidor/releases/tag/0.1.1) - 2017-11-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 - Update TypeScript Compiler Options (see #43).
 
-- Rename class to PixiContainerController (see #44).
+- Fix typo in class name PixiContainerController (see #44).
 
 - Update dev dependencies to latest version.
 

--- a/example/components/ColorButton.ts
+++ b/example/components/ColorButton.ts
@@ -1,3 +1,10 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017 RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
 import { Container, Graphics, Text, TextStyle } from "pixi.js";
 
 export class ColorButton extends Container {

--- a/example/config/ExampleConfig.ts
+++ b/example/config/ExampleConfig.ts
@@ -1,3 +1,10 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017 RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
 import { Event, IConfig, IEventDispatcher, inject, injectable } from "@robotlegsjs/core";
 import { IMediatorMap } from "@robotlegsjs/pixi";
 

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,3 +1,10 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017 RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
 // tslint:disable-next-line:no-reference
 /// <reference path="../node_modules/@robotlegsjs/pixi/definitions/pixi.d.ts" />
 

--- a/example/mediators/FloatingViewMediator.ts
+++ b/example/mediators/FloatingViewMediator.ts
@@ -1,3 +1,10 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017 RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
 import { Event, injectable } from "@robotlegsjs/core";
 import { Mediator } from "@robotlegsjs/pixi";
 

--- a/example/mediators/PalidorViewMediator.ts
+++ b/example/mediators/PalidorViewMediator.ts
@@ -1,3 +1,10 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017 RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
 import { Event, injectable } from "@robotlegsjs/core";
 import { Mediator } from "@robotlegsjs/pixi";
 

--- a/example/mediators/RobotlegsViewMediator.ts
+++ b/example/mediators/RobotlegsViewMediator.ts
@@ -1,3 +1,10 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017 RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
 import { Event, injectable } from "@robotlegsjs/core";
 import { Mediator } from "@robotlegsjs/pixi";
 

--- a/example/views/AbstractView.ts
+++ b/example/views/AbstractView.ts
@@ -1,3 +1,10 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017 RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
 import { Container, Graphics, Sprite, Text, TextStyle } from "pixi.js";
 
 import { ColorButton } from "./../components/ColorButton";

--- a/example/views/FloatingView.ts
+++ b/example/views/FloatingView.ts
@@ -1,3 +1,10 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017 RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
 import { ColorButton } from "./../components/ColorButton";
 import { Container, Graphics, TextStyle, Text } from "pixi.js";
 

--- a/example/views/PalidorView.ts
+++ b/example/views/PalidorView.ts
@@ -1,3 +1,10 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017 RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
 import { AbstractView } from "./AbstractView";
 
 export class PalidorView extends AbstractView {

--- a/example/views/RobotlegsView.ts
+++ b/example/views/RobotlegsView.ts
@@ -1,3 +1,10 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017 RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
 import { AbstractView } from "./AbstractView";
 
 export class RobotlegsView extends AbstractView {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@
 //  NOTICE: You are permitted to use, modify, and distribute this file
 //  in accordance with the terms of the license agreement accompanying it.
 // ------------------------------------------------------------------------------
+
 /**
  * PalidorPixiExtension Extension
  */

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,6 @@ export { IFlowViewMapping } from "./robotlegs/bender/extensions/palidorPixi/api/
 export { PalidorEvent } from "./robotlegs/bender/extensions/palidorPixi/events/PalidorEvent";
 export { FlowManager } from "./robotlegs/bender/extensions/palidorPixi/impl/FlowManager";
 export { FlowViewMapping } from "./robotlegs/bender/extensions/palidorPixi/impl/FlowViewMapping";
-export { PixiContainerContoller } from "./robotlegs/bender/extensions/palidorPixi/impl/PixiContainerContoller";
+export { PixiContainerController } from "./robotlegs/bender/extensions/palidorPixi/impl/PixiContainerController";
 export { PalidorPixiExtension } from "./robotlegs/bender/extensions/palidorPixi/PalidorPixiExtension";
 export { PalidorBundle } from "./robotlegs/bender/bundles/palidor/PalidorBundle";

--- a/src/robotlegs/bender/bundles/palidor/PalidorBundle.ts
+++ b/src/robotlegs/bender/bundles/palidor/PalidorBundle.ts
@@ -1,3 +1,10 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017 RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
 import {
     ConsoleLoggingExtension,
     DirectCommandMapExtension,

--- a/src/robotlegs/bender/extensions/palidorPixi/PalidorPixiExtension.ts
+++ b/src/robotlegs/bender/extensions/palidorPixi/PalidorPixiExtension.ts
@@ -9,7 +9,7 @@ import { IContainerController } from "./api/IContainerController";
 import { IFlowManager } from "./api/IFlowManager";
 
 import { FlowManager } from "./impl/FlowManager";
-import { PixiContainerContoller } from "./impl/PixiContainerContoller";
+import { PixiContainerController } from "./impl/PixiContainerController";
 
 import { IContext, IExtension, IInjector, instanceOfType } from "@robotlegsjs/core";
 
@@ -27,7 +27,7 @@ export class PalidorPixiExtension implements IExtension {
     private handleContextView(contextView: IContextView): void {
         this._injector
             .bind(IContainerController)
-            .to(PixiContainerContoller)
+            .to(PixiContainerController)
             .inSingletonScope();
         this._injector
             .bind(IFlowManager)

--- a/src/robotlegs/bender/extensions/palidorPixi/impl/PixiContainerController.ts
+++ b/src/robotlegs/bender/extensions/palidorPixi/impl/PixiContainerController.ts
@@ -12,7 +12,7 @@ import { injectable, inject } from "@robotlegsjs/core";
 import { IContextView } from "@robotlegsjs/pixi";
 
 @injectable()
-export class PixiContainerContoller implements IContainerController {
+export class PixiContainerController implements IContainerController {
     private _root: Container;
 
     private _staticLayer: Container;

--- a/test/robotlegs/bender/bundles/palidor/palidorBundle.test.ts
+++ b/test/robotlegs/bender/bundles/palidor/palidorBundle.test.ts
@@ -4,6 +4,7 @@
 //  NOTICE: You are permitted to use, modify, and distribute this file
 //  in accordance with the terms of the license agreement accompanying it.
 // ------------------------------------------------------------------------------
+
 import "../../../../entry";
 
 import { Context, IContext } from "@robotlegsjs/core";

--- a/test/robotlegs/bender/extensions/palidorPixi/impl/pixiContainerController.test.ts
+++ b/test/robotlegs/bender/extensions/palidorPixi/impl/pixiContainerController.test.ts
@@ -7,7 +7,7 @@
 
 import "./../../../../../entry";
 
-import { PixiContainerContoller } from "../../../../../../src";
+import { PixiContainerController } from "../../../../../../src";
 
 import { assert } from "chai";
 import { Container } from "pixi.js";
@@ -15,7 +15,7 @@ import { Container } from "pixi.js";
 import { Utils } from "./../support/Utils";
 
 describe("PixiContainerController", () => {
-    let controller: PixiContainerContoller;
+    let controller: PixiContainerController;
     let view: Container;
 
     beforeEach(() => {

--- a/test/robotlegs/bender/extensions/palidorPixi/support/Utils.ts
+++ b/test/robotlegs/bender/extensions/palidorPixi/support/Utils.ts
@@ -5,7 +5,7 @@
 //  in accordance with the terms of the license agreement accompanying it.
 // ------------------------------------------------------------------------------
 
-import { IContainerController, IFlowManager, FlowManager, PixiContainerContoller, PalidorPixiExtension } from "./../../../../../../src";
+import { IContainerController, IFlowManager, FlowManager, PixiContainerController, PalidorPixiExtension } from "./../../../../../../src";
 
 import { Container } from "pixi.js";
 
@@ -24,13 +24,13 @@ export class Utils {
         return <FlowManager>context.injector.get(IFlowManager);
     }
 
-    public static getInstanceOfPixiContainerController(): PixiContainerContoller {
+    public static getInstanceOfPixiContainerController(): PixiContainerController {
         let context = new Context();
         context.install(MVCSBundle);
         context.install(PixiBundle);
         context.install(PalidorPixiExtension);
         context.configure(new ContextView(new Container()));
 
-        return <PixiContainerContoller>context.injector.get(IContainerController);
+        return <PixiContainerController>context.injector.get(IContainerController);
     }
 }


### PR DESCRIPTION
- Fix typo in class named **PixiContainerController** (see #44).

    - The name of the class changed from **PixiContainerContoller** to **PixiContainerController**, don't forget to update your import statements.

    - A copyright message was added to all source files.